### PR TITLE
fix: serialize Date to string

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,8 +56,8 @@ export function apply(ctx: Context) {
         if (!pendings.length) return session.text('.no-pending')
         const result = [session.text('.list-header')]
         for (const pending of pendings) {
-          const type = session.text(`.types.${pending.code ? 'reboot' : 'shutdown'}`)
-          result.push(session.text('.list-item', [type, pending.date]))
+          const action = pending.code ? 'reboot' : 'poweroff'
+          result.push(session.text(`.list-item.${action}`, [pending.date.toString()]))
         }
         return result.join('\n')
       }
@@ -94,7 +94,7 @@ export function apply(ctx: Context) {
 
       if (wall || options.wall) {
         const path = `commands.shutdown.wall-messages.${action}`
-        ctx.broadcast(wall || <i18n path={path}>{date}</i18n>)
+        ctx.broadcast(wall || <i18n path={path}>{date.toString()}</i18n>)
       }
       return session.text('.' + action, [date.toString()])
     })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,7 +96,7 @@ export function apply(ctx: Context) {
         const path = `commands.shutdown.wall-messages.${action}`
         ctx.broadcast(wall || <i18n path={path}>{date}</i18n>)
       }
-      return session.text('.' + action, [date])
+      return session.text('.' + action, [date.toString()])
     })
 }
 


### PR DESCRIPTION
```
2023-02-28 03:50:25 [W] command shutdown 
                        TypeError: Invalid content: Tue Feb 28 2023 03:51:25 GMT+0800 (China Standard Time)
                            at toElement (/home/programripper/koishi-app/node_modules/@satorijs/element/lib/index.cjs:19:11)
                            at toElementArray (/home/programripper/koishi-app/node_modules/@satorijs/element/lib/index.cjs:27:13)
                            at parseContent (/home/programripper/koishi-app/node_modules/@satorijs/element/lib/index.cjs:242:26)
                            at Function.parse (/home/programripper/koishi-app/node_modules/@satorijs/element/lib/index.cjs:232:5)
                            at I18n.render (/home/programripper/koishi-app/node_modules/@koishijs/core/lib/index.cjs:515:27)
                            at I18n.text (/home/programripper/koishi-app/node_modules/@koishijs/core/lib/index.cjs:536:23)
                            at Session2.text (/home/programripper/koishi-app/node_modules/@koishijs/core/lib/index.cjs:2094:26)
                            at _Command.<anonymous> (/home/programripper/koishi-app/node_modules/koishi-plugin-shutdown/lib/index.js:76:24)
                            at Array.<anonymous> (/home/programripper/koishi-app/node_modules/@koishijs/core/lib/index.cjs:1631:27)
                            at argv.next (/home/programripper/koishi-app/node_modules/@koishijs/core/lib/index.cjs:1643:60)
```